### PR TITLE
fix: recreate cicdrun.sh for each runactions call

### DIFF
--- a/scripts-rover/runactions.sh
+++ b/scripts-rover/runactions.sh
@@ -50,7 +50,7 @@ fi
 if [ "${proceed,,}" = "yes" ];
 then
   mkdir -p .actions
-  echo "/tf/rover/gorover.sh ${env} plan" >> .actions/cicdrun.sh
+  echo "/tf/rover/gorover.sh ${env} plan" > .actions/cicdrun.sh
   echo "/tf/rover/gorover.sh $@ -auto-approve" >> .actions/cicdrun.sh
   chmod +x .actions/cicdrun.sh
   git add .


### PR DESCRIPTION
@bernardmaltais heads up that I had to build a new rover image to fix a bug with my change:
```
Version sscspccloudnuage/rover:2012.0817 created.
Version sscspccloudnuage/rover:latest created.
```